### PR TITLE
Update functions.cfm

### DIFF
--- a/events/functions.cfm
+++ b/events/functions.cfm
@@ -89,7 +89,13 @@
 	<cfargument name="permission" required="true" hint="The permission name to check against">
 	<cfscript> 
 		if(_permissionsSetup() AND structKeyExists(application.rbs.permission, arguments.permission)){
-			return application.rbs.permission[arguments.permission][_returnUserRole()];
+			var retValue = application.rbs.permission[arguments.permission][_returnUserRole()];
+			if(retValue == 1){
+				return true;
+			} else {
+				return false;
+			}
+			//return application.rbs.permission[arguments.permission][_returnUserRole()];
 		} 
 	</cfscript>
 </cffunction>


### PR DESCRIPTION
Seems a bug in Coldfusion 10 makes isboolean(1); return false. As a result value of "application.rbs.permission[arguments.permission][_returnUserRole()]" can not be converted to a boolean to be used in line 106.
